### PR TITLE
Instructions for building namecoind on Ubuntu 32-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,47 @@ BUILDING
 
 Building is supported on Linux, Windows and Mac. For building on windows you can use the scripts in ./contrib/easywinbuilder. Find build instructions on http://dot-bit.org.
 
+## Building 'namecoind' on Ubuntu
+
+The following instructions are for building a headless namecoin daemon (namecoind) on a **32-bit Ubuntu 13** and do **not** apply to 64-bit versions. First install the required packages:
+
+```
+sudo apt-get update
+sudo apt-get install git build-essential libboost-dev libdb5.1++-dev
+sudo apt-get install libboost-chrono-dev libboost-date-time-dev libboost-filesystem-dev libboost-program-options-dev
+sudo apt-get install libboost-serialization-dev libboost-system-dev libboost-thread-dev libglibmm-2.4-dev
+sudo apt-get install qt4-qmake libqt4-dev qt4-linguist-tools libssl-dev 
+```
+Next, checkout the github repo and the correct release: 
+
+```
+git clone https://github.com/namecoinq/namecoinq.git
+cd namecoinq/
+git checkout vQ.3.72
+```
+
+**Note:** You should only trust **version Q.3.72** or higher with names because of a severe bug that was discovered in Aug 2013.
+
+Build namecoind:
+```
+qmake "USE_UPNP=-"
+cd src
+make
+```
+Configure namecoind:
+```
+touch ~/.namecoin/namecoin.conf
+chmod 600 ~/.namecoin/namecoin.conf
+```
+Copy/paste the following into namecoin.conf after making the appropriate edits
+```
+rpcuser=<your_username>
+rpcpassword=<your_long_secure_password>
+rpcport=<the_port_you_want_to_use>
+```
+Now, you can run namecoind and verfiy that it is running:
+```
+cd namecoinq/src/
+./namecoind
+./namecoind getinfo 
+```


### PR DESCRIPTION
I recently tested compiling vQ.3.72 on Fedora and Ubuntu using instructions from:

http://dot-bit.org/BuildNamecoinQTFromSource

I found that vQ.3.72 doesn't compile on 64-bit distributions (see issue #2) but the headless namecoin daemon can be compiled (without errors/warnings) on Ubuntu 32-bit. I haven't tested with Fedora 32-bit yet. 

I've added the instructions that worked for me. The main difference from http://dot-bit.org/BuildNamecoinQTFromSource is that you need libglibmm-2.4-dev and I'm only interested in compiling and running the headless daemon. 
