### PR TITLE
Update TLS dialog to support the v2 TLS spec

### DIFF
--- a/src/qt/configurenamedialog.cpp
+++ b/src/qt/configurenamedialog.cpp
@@ -70,7 +70,7 @@ ConfigureNameDialog::ConfigureNameDialog(const QString &name_, const QString &da
         // Check conformance to DNS type
         bool ok = true;
         QStringList ns;
-        QString translate, fingerprint;
+        QString translate, tls;
         BOOST_FOREACH(json_spirit::Pair& item, val.get_obj())
         {
             if (item.name_ == "ns")
@@ -98,10 +98,10 @@ ConfigureNameDialog::ConfigureNameDialog(const QString &name_, const QString &da
                 else
                     ok = false;
             }
-            else if (item.name_ == "fingerprint")
+            else if (item.name_ == "tls")
             {
                 if (item.value_.type() == json_spirit::str_type)
-                    fingerprint = QString::fromStdString(item.value_.get_str());
+                    tls = QString::fromStdString(item.value_.get_str());
                 else
                     ok = false;
             }
@@ -118,21 +118,21 @@ ConfigureNameDialog::ConfigureNameDialog(const QString &name_, const QString &da
         {
             ui->nsEdit->setPlainText(ns.join("\n"));
             ui->nsTranslateEdit->setText(translate);
-            ui->nsFingerprintEdit->setText(fingerprint);
+            ui->nsTLSEdit->setText(tls);
             ui->tabWidget->setCurrentWidget(ui->tab_dns);
         }
         else
         {
             // Check conformance to IP type
             json_spirit::Object obj = val.get_obj();
-            QString ip, fingerprint;
+            QString ip, tls;
             json_spirit::Value ipVal = json_spirit::find_value(obj, "ip");
             json_spirit::Value mapVal = json_spirit::find_value(obj, "map");
-            json_spirit::Value fingerprintVal = json_spirit::find_value(obj, "fingerprint");
+            json_spirit::Value tlsVal = json_spirit::find_value(obj, "tls");
             int n = 2;
-            if (fingerprintVal.type() == json_spirit::str_type)
+            if (tlsVal.type() == json_spirit::str_type)
             {
-                fingerprint = QString::fromStdString(fingerprintVal.get_str());
+                tls = QString::fromStdString(tlsVal.get_str());
                 n++;
             }
             if (obj.size() == n && ipVal.type() == json_spirit::str_type && mapVal.type() == json_spirit::obj_type)
@@ -160,7 +160,7 @@ ConfigureNameDialog::ConfigureNameDialog(const QString &name_, const QString &da
             if (ok)
             {
                 ui->ipEdit->setText(ip);
-                ui->ipFingerprintEdit->setText(fingerprint);
+                ui->ipTLSEdit->setText(tls);
                 ui->tabWidget->setCurrentWidget(ui->tab_ip);
             }
             else
@@ -303,9 +303,35 @@ void ConfigureNameDialog::SetDNS()
             translate += ".";
         data.push_back(json_spirit::Pair("translate", translate.toStdString()));
     }
-    QString fingerprint = ui->nsFingerprintEdit->text().trimmed();
-    if (!fingerprint.isEmpty())
-        data.push_back(json_spirit::Pair("fingerprint", fingerprint.toStdString()));
+
+	//TODO create a function to avoid copied code
+	json_spirit::Object tls_protocols;
+	json_spirit::Object tls_ports;
+	json_spirit::Array tls_fingerprints;
+	json_spirit::Array tls_data;
+	
+	QString TLSTypeBox = ui->nsTLSTypeBox->currentText().trimmed();
+	QString TLSProtocolBox = ui->nsTLSProtocolBox->currentText().trimmed();
+    QString TLSEdit = ui->nsTLSEdit->text().trimmed();
+	QString TLSPortEdit = ui->nsTLSPortEdit->text().trimmed();
+	int TLSincludeSubdomainsCheckBox = (int) ui->nsTLSincludeSubdomainsCheckBox->isChecked();
+	if (!TLSEdit.isEmpty() && TLSTypeBox.toStdString() != "None"){
+		
+		if(TLSTypeBox.toStdString() == "SHA256")
+			tls_data.push_back(json_spirit::Value(1));
+		else if (TLSTypeBox.toStdString() == "SHA512")
+			tls_data.push_back(json_spirit::Value(2));
+		
+		tls_data.push_back(json_spirit::Value(TLSEdit.toStdString()));
+		
+		tls_data.push_back(json_spirit::Value(TLSincludeSubdomainsCheckBox));
+		
+		tls_fingerprints.push_back(json_spirit::Value(tls_data));
+		tls_ports.push_back(json_spirit::Pair( TLSPortEdit.toStdString() , tls_fingerprints ));
+		tls_protocols.push_back(json_spirit::Pair( TLSProtocolBox.toStdString() , tls_ports ));
+		
+        data.push_back(json_spirit::Pair("tls", tls_protocols));
+	}
 
     ui->dataEdit->setText(QString::fromStdString(json_spirit::write_string(json_spirit::Value(data), false)));
 }
@@ -314,14 +340,43 @@ void ConfigureNameDialog::SetIP()
 {
     json_spirit::Object data;
     data.push_back(json_spirit::Pair("ip", ui->ipEdit->text().trimmed().toStdString()));
-    json_spirit::Object map, submap;
-    submap.push_back(json_spirit::Pair("ip", ui->ipEdit->text().trimmed().toStdString()));
-    map.push_back(json_spirit::Pair("*", submap));
-    data.push_back(json_spirit::Pair("map", map));
-    QString ipFingerprint = ui->ipFingerprintEdit->text().trimmed();
-    if (!ipFingerprint.isEmpty())
-        data.push_back(json_spirit::Pair("fingerprint", ipFingerprint.toStdString()));
+	//disable adding map because it only makes sense to add map when subdomains are actually specified
+    //json_spirit::Object map, submap;
+    //submap.push_back(json_spirit::Pair("ip", ui->ipEdit->text().trimmed().toStdString()));
 
+	//TODO create a function to avoid copied code
+	json_spirit::Object tls_protocols;
+	json_spirit::Object tls_ports;
+	json_spirit::Array tls_fingerprints;
+	json_spirit::Array tls_data;
+	
+	QString TLSTypeBox = ui->ipTLSTypeBox->currentText().trimmed();
+	QString TLSProtocolBox = ui->ipTLSProtocolBox->currentText().trimmed();
+    QString TLSEdit = ui->ipTLSEdit->text().trimmed();
+	QString TLSPortEdit = ui->ipTLSPortEdit->text().trimmed();
+	int TLSincludeSubdomainsCheckBox = (int) ui->ipTLSincludeSubdomainsCheckBox->isChecked();
+	if (!TLSEdit.isEmpty() && TLSTypeBox.toStdString() != "None"){
+		
+		if(TLSTypeBox.toStdString() == "SHA256")
+			tls_data.push_back(json_spirit::Value(1));
+		else if (TLSTypeBox.toStdString() == "SHA512")
+			tls_data.push_back(json_spirit::Value(2));
+		
+		tls_data.push_back(json_spirit::Value(TLSEdit.toStdString()));
+		
+		tls_data.push_back(json_spirit::Value(TLSincludeSubdomainsCheckBox));
+		
+		tls_fingerprints.push_back(json_spirit::Value(tls_data));
+		tls_ports.push_back(json_spirit::Pair( TLSPortEdit.toStdString() , tls_fingerprints ));
+		tls_protocols.push_back(json_spirit::Pair( TLSProtocolBox.toStdString() , tls_ports ));
+		
+		//submap.push_back(json_spirit::Pair("tls", tls_protocols));
+        data.push_back(json_spirit::Pair("tls", tls_protocols));
+	}
+
+	//map.push_back(json_spirit::Pair("*", submap));
+    //data.push_back(json_spirit::Pair("map", map));
+	
     ui->dataEdit->setText(QString::fromStdString(json_spirit::write_string(json_spirit::Value(data), false)));
 }
 

--- a/src/qt/configurenamedialog.cpp
+++ b/src/qt/configurenamedialog.cpp
@@ -340,9 +340,11 @@ void ConfigureNameDialog::SetIP()
 {
     json_spirit::Object data;
     data.push_back(json_spirit::Pair("ip", ui->ipEdit->text().trimmed().toStdString()));
-	//disable adding map because it only makes sense to add map when subdomains are actually specified
-    //json_spirit::Object map, submap;
-    //submap.push_back(json_spirit::Pair("ip", ui->ipEdit->text().trimmed().toStdString()));
+	
+	//we need to add the data into a map and also directly because without map, we are 
+	//referencing a bare domain and with a wildcard map, we are referencing all subdomains
+    json_spirit::Object map, submap;
+    submap.push_back(json_spirit::Pair("ip", ui->ipEdit->text().trimmed().toStdString()));
 
 	//TODO create a function to avoid copied code
 	json_spirit::Object tls_protocols;
@@ -370,12 +372,12 @@ void ConfigureNameDialog::SetIP()
 		tls_ports.push_back(json_spirit::Pair( TLSPortEdit.toStdString() , tls_fingerprints ));
 		tls_protocols.push_back(json_spirit::Pair( TLSProtocolBox.toStdString() , tls_ports ));
 		
-		//submap.push_back(json_spirit::Pair("tls", tls_protocols));
+		submap.push_back(json_spirit::Pair("tls", tls_protocols));
         data.push_back(json_spirit::Pair("tls", tls_protocols));
 	}
 
-	//map.push_back(json_spirit::Pair("*", submap));
-    //data.push_back(json_spirit::Pair("map", map));
+	map.push_back(json_spirit::Pair("*", submap));
+    data.push_back(json_spirit::Pair("map", map));
 	
     ui->dataEdit->setText(QString::fromStdString(json_spirit::write_string(json_spirit::Value(data), false)));
 }

--- a/src/qt/configurenamedialog.h
+++ b/src/qt/configurenamedialog.h
@@ -31,9 +31,19 @@ public slots:
     void on_pasteButton_clicked();
     void on_nsEdit_textChanged()                              { if (initialized) SetDNS(); }
     void on_nsTranslateEdit_textChanged(const QString &text)  { if (initialized) SetDNS(); }
-    void on_nsFingerprintEdit_textChanged()                   { if (initialized) SetDNS(); }
+    void on_nsTLSEdit_textChanged()							  { if (initialized) SetDNS(); }
+	void on_nsTLSPortEdit_textChanged()                   	  { if (initialized) SetDNS(); }
+	void on_nsTLSProtocolBox_currentIndexChanged()            { if (initialized) SetDNS(); }
+	void on_nsTLSTypeBox_currentIndexChanged()                { if (initialized) SetDNS(); }
+	void on_nsTLSincludeSubdomainsCheckBox_stateChanged()     { if (initialized) SetDNS(); }
+
     void on_ipEdit_textChanged(const QString &text)           { if (initialized) SetIP();  }
-    void on_ipFingerprintEdit_textChanged()                   { if (initialized) SetIP(); }
+    void on_ipTLSEdit_textChanged()                   		  {	if (initialized) SetIP(); }
+	void on_ipTLSPortEdit_textChanged()                   	  { if (initialized) SetIP(); }
+	void on_ipTLSProtocolBox_currentIndexChanged()            { if (initialized) SetIP(); }
+	void on_ipTLSTypeBox_currentIndexChanged()                { if (initialized) SetIP(); }
+	void on_ipTLSincludeSubdomainsCheckBox_stateChanged()     { if (initialized) SetIP(); }	
+	
     void on_dataEdit_textChanged(const QString &text);
 
 private:

--- a/src/qt/forms/configurenamedialog.ui
+++ b/src/qt/forms/configurenamedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>687</width>
-    <height>369</height>
+    <width>858</width>
+    <height>466</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -82,247 +82,6 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QTabWidget" name="tabWidget">
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <widget class="QWidget" name="tab_dns">
-        <attribute name="title">
-         <string>D&amp;NS Configuration</string>
-        </attribute>
-        <layout class="QFormLayout" name="formLayout_2">
-         <property name="fieldGrowthPolicy">
-          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>&amp;Name servers:
-(one per line,
-host or IP)</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="buddy">
-            <cstring>nsEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QPlainTextEdit" name="nsEdit">
-           <property name="toolTip">
-            <string>Enter name servers as host names (preferable), or IP addresses. E.g.
-ns0.web-sweet-web.net
-ns1.web-sweet-web.net
-ns0.xname.org
-1.2.3.4
-1.2.3.5</string>
-           </property>
-           <property name="tabChangesFocus">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>T&amp;ranslate name:
-(optional)</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="buddy">
-            <cstring>nsTranslateEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="nsTranslateEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter substitution name that will be used in DNS queries.&lt;/p&gt;&lt;p&gt;For example: bitcoin.org&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_9">
-           <property name="text">
-            <string>&amp;SSL fingerprint:
-(optional)</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="buddy">
-            <cstring>nsFingerprintEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QLineEdit" name="nsFingerprintEdit">
-           <property name="toolTip">
-            <string>Enter SSL certificate fingerprint if you want to use HTTPS</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <spacer name="verticalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="3" column="1">
-          <spacer name="verticalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="tab_ip">
-        <attribute name="title">
-         <string>&amp;IP Configuration</string>
-        </attribute>
-        <layout class="QFormLayout" name="formLayout_3">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>I&amp;P Address:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="buddy">
-            <cstring>nsTranslateEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="ipEdit">
-           <property name="toolTip">
-            <string>IP address, e.g. 1.2.3.4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>Subdomains will be mapped to the same IP</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLineEdit" name="ipFingerprintEdit">
-           <property name="toolTip">
-            <string>Enter SSL certificate fingerprint if you want to use HTTPS</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>&amp;SSL fingerprint:
-(optional)</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="buddy">
-            <cstring>ipFingerprintEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <spacer name="verticalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>12</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="tab_json">
-        <attribute name="title">
-         <string>&amp;Custom Configuration</string>
-        </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Enter JSON string, e.g. {&amp;quot;ns&amp;quot;: [&amp;quot;1.2.3.4&amp;quot;, &amp;quot;1.2.3.5&amp;quot;]}&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;See &lt;a href=&quot;http://dot-bit.org/HowToRegisterAndConfigureBitDomains&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;How to Register and Configure Bit Domains&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="openExternalLinks">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="dataEdit">
-           <property name="toolTip">
-            <string>Enter JSON string that will be associated with the name</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="labelJsonValid">
-           <property name="text">
-            <string notr="true">TextLabel</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </widget>
-     </item>
      <item row="5" column="1">
       <spacer name="verticalSpacer">
        <property name="orientation">
@@ -345,6 +104,68 @@ p, li { white-space: pre-wrap; }
         <cstring>copyButton</cstring>
        </property>
       </widget>
+     </item>
+     <item row="6" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="labelAddress">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Namecoin address to which the name is assigned</string>
+         </property>
+         <property name="text">
+          <string notr="true">N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9</string>
+         </property>
+         <property name="indent">
+          <number>3</number>
+         </property>
+         <property name="buddy">
+          <cstring>transferTo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="copyButton">
+         <property name="toolTip">
+          <string>Copy address to clipboard</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../bitcoin.qrc">
+           <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+         </property>
+         <property name="shortcut">
+          <string>Alt+P</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
      <item row="7" column="0">
       <widget class="QLabel" name="labelTransferTo">
@@ -424,67 +245,458 @@ Leave empty, if not needed.</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QLabel" name="labelAddress">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Namecoin address to which the name is assigned</string>
-         </property>
-         <property name="text">
-          <string notr="true">N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9</string>
-         </property>
-         <property name="indent">
-          <number>3</number>
-         </property>
-         <property name="buddy">
-          <cstring>transferTo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="copyButton">
-         <property name="toolTip">
-          <string>Copy address to clipboard</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../bitcoin.qrc">
-           <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
-         </property>
-         <property name="shortcut">
-          <string>Alt+P</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+     <item row="4" column="1">
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="tab_dns">
+        <attribute name="title">
+         <string>D&amp;NS Configuration</string>
+        </attribute>
+        <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>&amp;Name servers:
+(one per line,
+host or IP)</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+           <property name="buddy">
+            <cstring>nsEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QPlainTextEdit" name="nsEdit">
+           <property name="toolTip">
+            <string>Enter name servers as host names (preferable), or IP addresses. E.g.
+ns0.web-sweet-web.net
+ns1.web-sweet-web.net
+ns0.xname.org
+1.2.3.4
+1.2.3.5</string>
+           </property>
+           <property name="tabChangesFocus">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <spacer name="verticalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Maximum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>T&amp;ranslate name:
+(optional)</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+           <property name="buddy">
+            <cstring>nsTranslateEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="nsTranslateEdit">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter substitution name that will be used in DNS queries.&lt;/p&gt;&lt;p&gt;For example: bitcoin.org&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <spacer name="verticalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Maximum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>TLS fingerprint:
+(optional)</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_12">
+             <property name="text">
+              <string>Type:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="nsTLSTypeBox">
+             <item>
+              <property name="text">
+               <string>None</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>SHA256</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>SHA512</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_13">
+             <property name="text">
+              <string>Fingerprint:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="nsTLSEdit">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Enter TLS certificate fingerprint for verification</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_11">
+             <property name="text">
+              <string>Port:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="nsTLSPortEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>443</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_17">
+             <property name="text">
+              <string>Protocol:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="nsTLSProtocolBox">
+             <item>
+              <property name="text">
+               <string>tcp</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>udp</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>sctp</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="nsTLSincludeSubdomainsCheckBox">
+             <property name="layoutDirection">
+              <enum>Qt::RightToLeft</enum>
+             </property>
+             <property name="text">
+              <string>Include Subdomains?</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_ip">
+        <attribute name="title">
+         <string>&amp;IP Configuration</string>
+        </attribute>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>I&amp;P Address:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+           <property name="buddy">
+            <cstring>nsTranslateEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="ipEdit">
+           <property name="toolTip">
+            <string>IP address, e.g. 1.2.3.4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Subdomains will be mapped to the same IP</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>TLS fingerprint:
+(optional)</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Maximum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>12</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="3" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QLabel" name="label_14">
+             <property name="text">
+              <string>Type:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="ipTLSTypeBox">
+             <item>
+              <property name="text">
+               <string>None</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>SHA256</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>SHA512</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>Fingerprint:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="ipTLSEdit"/>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_16">
+             <property name="text">
+              <string>Port:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="ipTLSPortEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>443</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_18">
+             <property name="text">
+              <string>Protocol:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="ipTLSProtocolBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <item>
+              <property name="text">
+               <string>tcp</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>udp</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>sctp</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="ipTLSincludeSubdomainsCheckBox">
+             <property name="layoutDirection">
+              <enum>Qt::RightToLeft</enum>
+             </property>
+             <property name="text">
+              <string>Include Subdomains?</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_json">
+        <attribute name="title">
+         <string>&amp;Custom Configuration</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Enter JSON string, e.g. {&amp;quot;ns&amp;quot;: [&amp;quot;1.2.3.4&amp;quot;, &amp;quot;1.2.3.5&amp;quot;]}&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;See &lt;a href=&quot;http://dot-bit.org/HowToRegisterAndConfigureBitDomains&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;How to Register and Configure Bit Domains&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="dataEdit">
+           <property name="toolTip">
+            <string>Enter JSON string that will be associated with the name</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelJsonValid">
+           <property name="text">
+            <string notr="true">TextLabel</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Update the manage name dialog to support the new TLS json format as
discussed at http://dot-bit.org/forum/viewtopic.php?f=5&t=1137

Currently it only supports adding a single TLS record.

![namecoinq-window](https://f.cloud.github.com/assets/6159006/1730120/1a54c5e6-62d4-11e3-9dd5-f052e2f05c86.PNG)
